### PR TITLE
Cap page chrome to a centred 1520px frame on ultrawide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # claude code workspace
 /.claude
 /docs
+/.superpowers
 
 # extensions
 /.vscode/

--- a/src/components/BlueBlock/BlueBlock.module.scss
+++ b/src/components/BlueBlock/BlueBlock.module.scss
@@ -22,10 +22,14 @@
     }
 }
 
-// About keeps the deployed right-edge stripe — the wide `.block` pulled in to the
-// right ~20% so it sits beside the offset content column rather than behind it.
+// About keeps the right-edge stripe (the wide `.block` pulled in to the right ~20%).
+// Its left edge anchors to the frame band — the same band the About content column is now
+// capped to — so the capped navbar's ABOUT link always sits over navy and the stripe never
+// collides with the content (the column ends at 62% of the band, the stripe starts at 80%).
+// Below 1920 the gutter is 0 and the band is the viewport, so this resolves to 80%. The
+// right edge still bleeds to the viewport edge.
 .stripe {
     @media (min-width: 992px) {
-        left: 80%;
+        left: calc(var(--frame-gutter) + var(--frame-band) * 0.8);
     }
 }

--- a/src/components/BlueBlock/BlueBlock.module.scss
+++ b/src/components/BlueBlock/BlueBlock.module.scss
@@ -26,7 +26,7 @@
 // Its left edge anchors to the frame band — the same band the About content column is now
 // capped to — so the capped navbar's ABOUT link always sits over navy and the stripe never
 // collides with the content (the column ends at 62% of the band, the stripe starts at 80%).
-// Below 1920 the gutter is 0 and the band is the viewport, so this resolves to 80%. The
+// Below the cap the gutter is 0 and the band is the viewport, so this resolves to 80%. The
 // right edge still bleeds to the viewport edge.
 .stripe {
     @media (min-width: 992px) {

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -19,10 +19,11 @@
         position: relative;
         text-align: left;
         padding-top: 0;
-        // 3% inset, kept band-relative so it freezes above 1920 instead of growing with the
-        // viewport. Below 1920 the band is the viewport, so this is identical to the old
-        // `padding-left: 3%`.
-        padding-left: calc(var(--frame-band) * 0.03);
+        // 3.2% inset, matching the navbar brand and contact icons so all three chrome
+        // elements share one left edge. Band-relative, so it freezes above 1920 instead of
+        // growing with the viewport. (Below 1920 this is 3.2% of the viewport — ~3px inside
+        // the original `padding-left: 3%`, the deliberate trade for that alignment.)
+        padding-left: calc(var(--frame-band) * 0.032);
     }
 }
 

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,7 +1,10 @@
 @use '../../styles/styles';
 
 .container {
-    max-width: 1920px;
+    max-width: styles.$frame-max;
+    // Offset by the same 100vw-based gutter as the navbar so the two share a left edge and
+    // neither shifts between pages when a scrollbar comes and goes. 0 below the cap.
+    margin-left: var(--frame-gutter);
     height: 200px;
     text-align: center;
     padding-top: 32px;
@@ -16,7 +19,10 @@
         position: relative;
         text-align: left;
         padding-top: 0;
-        padding-left: 3%;
+        // 3% inset, kept band-relative so it freezes above 1920 instead of growing with the
+        // viewport. Below 1920 the band is the viewport, so this is identical to the old
+        // `padding-left: 3%`.
+        padding-left: calc(var(--frame-band) * 0.03);
     }
 }
 

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -20,8 +20,8 @@
         text-align: left;
         padding-top: 0;
         // 3.2% inset, matching the navbar brand and contact icons so all three chrome
-        // elements share one left edge. Band-relative, so it freezes above 1920 instead of
-        // growing with the viewport. (Below 1920 this is 3.2% of the viewport — ~3px inside
+        // elements share one left edge. Band-relative, so it freezes above the cap instead of
+        // growing with the viewport. (Below the cap this is 3.2% of the viewport — ~3px inside
         // the original `padding-left: 3%`, the deliberate trade for that alignment.)
         padding-left: calc(var(--frame-band) * 0.032);
     }

--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -10,10 +10,10 @@
     justify-content: space-between;
     position: fixed;
     top: 0;
-    // Pin both edges to the frame gutter so the bar spans the centred band and caps at
-    // 1920. Driven by the same 100vw-based --frame-gutter as the rest of the chrome, so the
-    // bar can't shift between pages when a scrollbar appears/disappears. Below 1920 the
-    // gutter is 0, so the bar is full-width exactly as `width: 100vw` was.
+    // Pin both edges to the frame gutter so the bar spans the centred band and caps at the
+    // frame max. Driven by the same 100vw-based --frame-gutter as the rest of the chrome, so
+    // the bar can't shift between pages when a scrollbar appears/disappears. Below the cap
+    // the gutter is 0, so the bar is full-width exactly as `width: 100vw` was.
     left: var(--frame-gutter);
     right: var(--frame-gutter);
     height: 64px;
@@ -25,7 +25,7 @@
 
     @media (min-width: 992px) {
         // Inset resolves against the band (not the viewport), so brand + ABOUT freeze at
-        // the band edge above 1920 and line up with the footer and contact links.
+        // the band edge above the cap and line up with the footer and contact links.
         padding: 38px calc(var(--frame-band) * 0.032) 0;
         background-color: transparent;
     }

--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -10,7 +10,12 @@
     justify-content: space-between;
     position: fixed;
     top: 0;
-    width: 100vw;
+    // Pin both edges to the frame gutter so the bar spans the centred band and caps at
+    // 1920. Driven by the same 100vw-based --frame-gutter as the rest of the chrome, so the
+    // bar can't shift between pages when a scrollbar appears/disappears. Below 1920 the
+    // gutter is 0, so the bar is full-width exactly as `width: 100vw` was.
+    left: var(--frame-gutter);
+    right: var(--frame-gutter);
     height: 64px;
     @include no-margin;
     padding: 22px 9% 0 9%;
@@ -19,7 +24,9 @@
     z-index: 10;
 
     @media (min-width: 992px) {
-        padding: 38px 3.2% 0 3.2%;
+        // Inset resolves against the band (not the viewport), so brand + ABOUT freeze at
+        // the band edge above 1920 and line up with the footer and contact links.
+        padding: 38px calc(var(--frame-band) * 0.032) 0;
         background-color: transparent;
     }
 }

--- a/src/components/QuickLinks/QuickLinks.module.scss
+++ b/src/components/QuickLinks/QuickLinks.module.scss
@@ -7,8 +7,8 @@
 
     @media (min-width: 992px) {
         width: 80%;
-        // Freeze at 80% of the band and shift into the centred band on ultrawide. Below
-        // 1920 the band is the viewport, so max-width == width (80vw) and the gutter is 0.
+        // Freeze at 80% of the band and shift into the centred band on wide screens. Below
+        // the cap the band is the viewport, so max-width == width (80vw) and the gutter is 0.
         max-width: calc(var(--frame-band) * 0.8);
         margin-left: var(--frame-gutter);
         padding: 32px 11%;

--- a/src/components/QuickLinks/QuickLinks.module.scss
+++ b/src/components/QuickLinks/QuickLinks.module.scss
@@ -7,6 +7,10 @@
 
     @media (min-width: 992px) {
         width: 80%;
+        // Freeze at 80% of the band and shift into the centred band on ultrawide. Below
+        // 1920 the band is the viewport, so max-width == width (80vw) and the gutter is 0.
+        max-width: calc(var(--frame-band) * 0.8);
+        margin-left: var(--frame-gutter);
         padding: 32px 11%;
     }
 }
@@ -21,6 +25,9 @@
 
     @media (min-width: 992px) {
         width: 80%;
+        // Match .outerContainer so the prompt copy stays aligned with the pills.
+        max-width: calc(var(--frame-band) * 0.8);
+        margin-left: var(--frame-gutter);
         padding: 32px 11% 16px 11%;
     }
 }

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -13,8 +13,8 @@
         bottom: 0;
         padding-bottom: 50px;
         // Sit 3.2% in from the frame band's left edge — the same inset as the navbar brand,
-        // so the icons share the brand's left edge. Band-relative, so it freezes above 1920
-        // instead of growing with the viewport. (Below 1920 this is 3.2% of the viewport —
+        // so the icons share the brand's left edge. Band-relative, so it freezes above the cap
+        // instead of growing with the viewport. (Below the cap this is 3.2% of the viewport —
         // ~3px inside the original `margin-left: 3%`, a deliberate trade for that alignment.)
         left: calc(var(--frame-gutter) + var(--frame-band) * 0.032);
         z-index: 9;

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -12,7 +12,12 @@
         height: 40vh;
         bottom: 0;
         padding-bottom: 50px;
-        margin-left: 3%;
+        // Sit 3% in from the frame band's left edge — the original inset, kept band-relative
+        // so it freezes above 1920 instead of growing with the viewport. Below 1920 the
+        // gutter is 0 and the band is the viewport, so this is identical to the old
+        // `margin-left: 3%`. (The navbar brand uses 3.2%, so it sits a hair further in — the
+        // site's original proportion, now frozen rather than drifting at ultrawide.)
+        left: calc(var(--frame-gutter) + var(--frame-band) * 0.03);
         z-index: 9;
     }
 }

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -12,12 +12,11 @@
         height: 40vh;
         bottom: 0;
         padding-bottom: 50px;
-        // Sit 3% in from the frame band's left edge — the original inset, kept band-relative
-        // so it freezes above 1920 instead of growing with the viewport. Below 1920 the
-        // gutter is 0 and the band is the viewport, so this is identical to the old
-        // `margin-left: 3%`. (The navbar brand uses 3.2%, so it sits a hair further in — the
-        // site's original proportion, now frozen rather than drifting at ultrawide.)
-        left: calc(var(--frame-gutter) + var(--frame-band) * 0.03);
+        // Sit 3.2% in from the frame band's left edge — the same inset as the navbar brand,
+        // so the icons share the brand's left edge. Band-relative, so it freezes above 1920
+        // instead of growing with the viewport. (Below 1920 this is 3.2% of the viewport —
+        // ~3px inside the original `margin-left: 3%`, a deliberate trade for that alignment.)
+        left: calc(var(--frame-gutter) + var(--frame-band) * 0.032);
         z-index: 9;
     }
 }

--- a/src/components/Wrapper/Wrapper.module.scss
+++ b/src/components/Wrapper/Wrapper.module.scss
@@ -52,12 +52,14 @@
     }
 }
 
-// About drops the desktop spine cap + side padding so the page spans the full viewport
-// width. The offset column's percentages (About.module.scss) then resolve against the
-// viewport, reproducing the deployed layout. Must follow `.container` to win the override.
+// About uses the frame cap (not the 1080 spine) and drops the side padding, so the offset
+// column's percentages (About.module.scss) resolve against the centred 1920 band. The
+// content stays contained on ultrawide instead of drifting with the viewport, while below
+// 1920 the band is the viewport — the deployed layout, unchanged. Must follow `.container`
+// to win the override.
 .aboutPage {
     @media (min-width: styles.$bp-lg) {
-        max-width: none;
+        max-width: styles.$frame-max;
         padding: 0;
     }
 }

--- a/src/components/Wrapper/Wrapper.module.scss
+++ b/src/components/Wrapper/Wrapper.module.scss
@@ -53,9 +53,9 @@
 }
 
 // About uses the frame cap (not the 1080 spine) and drops the side padding, so the offset
-// column's percentages (About.module.scss) resolve against the centred 1920 band. The
+// column's percentages (About.module.scss) resolve against the centred frame band. The
 // content stays contained on ultrawide instead of drifting with the viewport, while below
-// 1920 the band is the viewport — the deployed layout, unchanged. Must follow `.container`
+// the cap the band is the viewport — the deployed layout, unchanged. Must follow `.container`
 // to win the override.
 .aboutPage {
     @media (min-width: styles.$bp-lg) {

--- a/src/styles/About.module.scss
+++ b/src/styles/About.module.scss
@@ -32,8 +32,9 @@
 }
 
 // At >=992 the About page reproduces the deployed offset column — a narrow column pushed
-// in from the left. Percentages are viewport-relative because Wrapper gives /about a
-// full-width canvas (.aboutPage). Below 992 it's full-width and Section provides the insets.
+// in from the left. Percentages resolve against Wrapper's frame-capped canvas (.aboutPage
+// caps at $frame-max), so the column stays contained on ultrawide instead of drifting with
+// the viewport. Below 992 it's full-width and Section provides the insets.
 .offsetColumn {
     @media (min-width: styles.$bp-lg) {
         width: 40%;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -9,7 +9,7 @@
 :root {
     // Frame cap: page chrome + content never exceed this width and centre on ultrawide.
     // --frame-band is the live content width (viewport, capped); --frame-gutter is the
-    // symmetric empty space on each side — 0 below the cap, growing only past 1920px.
+    // symmetric empty space on each side — 0 below the cap, growing past it.
     --frame-band: min(100vw, #{styles.$frame-max});
     --frame-gutter: calc((100vw - var(--frame-band)) / 2);
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -6,6 +6,14 @@
     box-sizing: border-box;
 }
 
+:root {
+    // Frame cap: page chrome + content never exceed this width and centre on ultrawide.
+    // --frame-band is the live content width (viewport, capped); --frame-gutter is the
+    // symmetric empty space on each side — 0 below the cap, growing only past 1920px.
+    --frame-band: min(100vw, #{styles.$frame-max});
+    --frame-gutter: calc((100vw - var(--frame-band)) / 2);
+}
+
 body {
     width: 100%;
     margin: 0;
@@ -25,7 +33,7 @@ body {
 
 main {
     width: 100%;
-    max-width: 1920px;
+    max-width: styles.$frame-max;
     padding: 0;
     margin: 0 auto;
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -42,6 +42,7 @@ $gap-section-lg: $space-7; // 96px — between sections, desktop
 $page-max: 1080px; // centered content container; banners/cards/figures fill this
 $measure: 680px; // ~66ch cap for body text at 17px base
 $card-pad-lg: 48px; // FrostedGlass interior padding at desktop
+$frame-max: 1920px; // outer cap for page chrome + content; centres on ultrawide
 
 @mixin font-display {
     font-display: swap;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -42,7 +42,7 @@ $gap-section-lg: $space-7; // 96px — between sections, desktop
 $page-max: 1080px; // centered content container; banners/cards/figures fill this
 $measure: 680px; // ~66ch cap for body text at 17px base
 $card-pad-lg: 48px; // FrostedGlass interior padding at desktop
-$frame-max: 1920px; // outer cap for page chrome + content; centres on ultrawide
+$frame-max: 1520px; // outer cap for page chrome + content; centres on wide screens
 
 @mixin font-display {
     font-display: swap;


### PR DESCRIPTION
## Summary

On wide and ultrawide monitors the page chrome (navbar, footer, contact links, project pills) and content stretched too wide. This caps them to a **centred 1520px band** so they stop sprawling, while the **BlueBlock keeps bleeding to the viewport edge**. 1520px matches the existing case-study content grid, so chrome and content share one frame.

## What's changed

- New `$frame-max: 1520px` design token plus two runtime CSS variables on `:root`:
  - `--frame-band: min(100vw, 1520px)` — the live (capped) content width
  - `--frame-gutter: calc((100vw - band) / 2)` — symmetric empty gutter, `0` below the cap
- All chrome is **positioned from `--frame-gutter`** and **inset from `--frame-band`**, so it (a) matches the original below the cap, (b) freezes at its 1520 proportion and centres above, and (c) doesn't shift between routes (`100vw` is scrollbar/page-independent).
- Brand, contact icons, and footer text share **one left edge** (3.2% of the band).
- `/about`: the offset content column is contained within the band, and the right-edge stripe is band-coupled so the white **ABOUT** link always sits over navy (it would otherwise land on the cream background and disappear). The stripe's right edge still bleeds to the viewport edge.
- Content caps (`main`, `.aboutPage`) and the case-study rail grid all sit at 1520, so chrome and content align.

## Verification

- Computed geometry (`getBoundingClientRect`) at **768 / 1440 / 1520 / 1600 / 1920 / 2560 / 3440 / 5120px** on Home, `/about`, and a case study.
- A/B vs the original code (`git stash`): below the cap is pixel-identical **except** the deliberate chrome inset change (3% → 3.2%, to align the brand, contact icons, and footer text on one edge).
- Clean `npm run build`; also confirmed in a production build (`next start`).